### PR TITLE
Add role-level model fallback support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,10 +32,11 @@ roles:
     models:
       junior: anthropic/claude-haiku-4-5
       medior:
-        primary: anthropic/claude-sonnet-4-6
-        fallbacks:
-          - openai/gpt-5-codex
-          - anthropic/claude-sonnet-4-5
+        model:
+          primary: anthropic/claude-sonnet-4-6
+          fallbacks:
+            - openai/gpt-5-codex
+            - anthropic/claude-sonnet-4-5
       senior: anthropic/claude-opus-4-6
   tester:
     models:
@@ -50,7 +51,7 @@ roles:
   # architect: false
 ```
 
-> **Tip:** Strings are treated as `{ primary: "<value>" }`. When editing by hand you can also use comma-separated shorthand (e.g. `primary, fallback1, fallback2`).
+> **Tip:** Keep simple cases as strings (equivalent to `{ model: "<value>" }`). To add fallbacks, wrap the spec under `model:` and list `primary` plus `fallbacks` as shown above. Comma-separated shorthand (`primary, fallback1, fallback2`) still works when editing by hand.
 
 **Role override fields** (all optional — only override what you need):
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,14 +24,18 @@ The `workflow.yaml` file configures roles, workflow states, and timeouts. Place 
 
 ### Role Configuration
 
-Override which LLM model powers each level, customize levels, or disable roles entirely:
+Override which LLM model powers each level, customize levels, or disable roles entirely. Models now support inline fallback chains:
 
 ```yaml
 roles:
   developer:
     models:
       junior: anthropic/claude-haiku-4-5
-      medior: anthropic/claude-sonnet-4-5
+      medior:
+        primary: anthropic/claude-sonnet-4-6
+        fallbacks:
+          - openai/gpt-5-codex
+          - anthropic/claude-sonnet-4-5
       senior: anthropic/claude-opus-4-6
   tester:
     models:
@@ -46,15 +50,19 @@ roles:
   # architect: false
 ```
 
+> **Tip:** Strings are treated as `{ primary: "<value>" }`. When editing by hand you can also use comma-separated shorthand (e.g. `primary, fallback1, fallback2`).
+
 **Role override fields** (all optional — only override what you need):
 
 | Field | Type | Description |
 |---|---|---|
 | `levels` | string[] | Available levels for this role |
 | `defaultLevel` | string | Default level when not specified |
-| `models` | Record<string, string> | Model ID per level |
+| `models` | Record<string, `ModelSpec`> | Primary + fallback list per level (string shorthand allowed) |
 | `emoji` | Record<string, string> | Emoji per level for announcements |
 | `completionResults` | string[] | Valid completion results |
+
+`ModelSpec = string | { primary: string; fallbacks?: string[] }`
 
 **Default models:**
 

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -98,18 +98,15 @@ const DEFAULT_MAX_WORKERS_PER_LEVEL = 2;
 
 function combineFallbacks(...lists: (string[] | undefined)[]): string[] {
   const seen = new Set<string>();
-  const merged: string[] = [];
   for (const list of lists) {
     if (!list) continue;
     for (const item of list) {
-      if (typeof item !== "string") continue;
-      if (!seen.has(item)) {
+      if (typeof item === "string") {
         seen.add(item);
-        merged.push(item);
       }
     }
   }
-  return merged;
+  return Array.from(seen);
 }
 
 function buildModelSpec(primary: string, ...fallbackLists: (string[] | undefined)[]): ModelSpec {
@@ -124,35 +121,52 @@ function parseModelEntry(roleId: string, level: string, entry: ModelEntry): Pars
     return { spec: entry };
   }
 
-  if (entry && typeof entry === "object") {
-    const anyEntry = entry as Record<string, unknown>;
-    const maxWorkers = typeof anyEntry.maxWorkers === "number" ? anyEntry.maxWorkers : undefined;
+  if (!entry || typeof entry !== "object") {
+    throw new Error(`Invalid model entry for ${roleId}.${level}: must specify a model or primary.`);
+  }
 
-    if (isModelSpecObject(entry as ModelSpec)) {
-      const specObj = entry as ModelSpecObject;
-      return { spec: buildModelSpec(specObj.primary, specObj.fallbacks), maxWorkers };
-    }
+  const recordEntry = entry as Record<string, unknown> & {
+    model?: unknown;
+    primary?: unknown;
+    fallbacks?: unknown;
+    maxWorkers?: unknown;
+  };
 
-    if (anyEntry.model !== undefined) {
-      const modelValue = anyEntry.model;
-      if (typeof modelValue === "string") {
-        return { spec: buildModelSpec(modelValue, anyEntry.fallbacks as string[] | undefined), maxWorkers };
-      }
-      if (modelValue && typeof modelValue === "object") {
-        const modelObj = modelValue as ModelSpecObject;
-        return {
-          spec: buildModelSpec(modelObj.primary, modelObj.fallbacks, anyEntry.fallbacks as string[] | undefined),
-          maxWorkers,
-        };
-      }
-    }
+  const maxWorkers = typeof recordEntry.maxWorkers === "number" ? recordEntry.maxWorkers : undefined;
+  const topLevelFallbacks = Array.isArray(recordEntry.fallbacks)
+    ? (recordEntry.fallbacks as string[])
+    : undefined;
 
-    if (typeof anyEntry.primary === "string") {
+  if (typeof recordEntry.primary === "string") {
+    return {
+      spec: buildModelSpec(recordEntry.primary, topLevelFallbacks),
+      maxWorkers,
+    };
+  }
+
+  if (recordEntry.model !== undefined) {
+    const modelValue = recordEntry.model;
+    if (typeof modelValue === "string") {
       return {
-        spec: buildModelSpec(anyEntry.primary, anyEntry.fallbacks as string[] | undefined),
+        spec: buildModelSpec(modelValue, topLevelFallbacks),
         maxWorkers,
       };
     }
+    if (modelValue && typeof modelValue === "object" && typeof (modelValue as Record<string, unknown>).primary === "string") {
+      const modelObj = modelValue as ModelSpecObject;
+      return {
+        spec: buildModelSpec(modelObj.primary, modelObj.fallbacks, topLevelFallbacks),
+        maxWorkers,
+      };
+    }
+  }
+
+  if (isModelSpecObject(entry as ModelSpec)) {
+    const specObj = entry as ModelSpecObject;
+    return {
+      spec: buildModelSpec(specObj.primary, specObj.fallbacks, topLevelFallbacks),
+      maxWorkers,
+    };
   }
 
   throw new Error(`Invalid model entry for ${roleId}.${level}: must specify a model or primary.`);

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -111,7 +111,7 @@ function combineFallbacks(...lists: (string[] | undefined)[]): string[] {
 
 function buildModelSpec(primary: string, ...fallbackLists: (string[] | undefined)[]): ModelSpec {
   const fallbacks = combineFallbacks(...fallbackLists);
-  return fallbacks.length > 0 ? { primary, fallbacks } : primary;
+  return { primary, fallbacks };
 }
 
 type ParsedModelEntry = { spec: ModelSpec; maxWorkers?: number };
@@ -177,10 +177,7 @@ function flattenModels(roleId: string, entries: Record<string, ModelEntry>): Rec
   const flat: Record<string, ModelSpec> = {};
   for (const [level, entry] of Object.entries(entries)) {
     const parsed = parseModelEntry(roleId, level, entry);
-    const normalized = normalizeModelSpec(parsed.spec);
-    flat[level] = normalized.fallbacks.length > 0
-      ? { primary: normalized.primary, fallbacks: normalized.fallbacks }
-      : normalized.primary;
+    flat[level] = normalizeModelSpec(parsed.spec);
   }
   return flat;
 }

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -12,6 +12,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
 import { ROLE_REGISTRY } from "../roles/registry.js";
+import { normalizeModelSpec, isModelSpecObject } from "../roles/types.js";
+import type { ModelSpec, ModelSpecObject } from "../roles/types.js";
 import { DEFAULT_WORKFLOW, type WorkflowConfig } from "../workflow/index.js";
 import { mergeConfig } from "./merge.js";
 import type { DevClawConfig, ResolvedConfig, ResolvedRoleConfig, ResolvedTimeouts, RoleOverride, ModelEntry } from "./types.js";
@@ -94,27 +96,91 @@ function buildDefaultConfig(): DevClawConfig {
 /** Default max workers per level when no override is set. */
 const DEFAULT_MAX_WORKERS_PER_LEVEL = 2;
 
-/** Flatten a ModelEntry map to string-only model IDs. */
-function flattenModels(entries: Record<string, ModelEntry>): Record<string, string> {
-  const flat: Record<string, string> = {};
+function combineFallbacks(...lists: (string[] | undefined)[]): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const list of lists) {
+    if (!list) continue;
+    for (const item of list) {
+      if (typeof item !== "string") continue;
+      if (!seen.has(item)) {
+        seen.add(item);
+        merged.push(item);
+      }
+    }
+  }
+  return merged;
+}
+
+function buildModelSpec(primary: string, ...fallbackLists: (string[] | undefined)[]): ModelSpec {
+  const fallbacks = combineFallbacks(...fallbackLists);
+  return fallbacks.length > 0 ? { primary, fallbacks } : primary;
+}
+
+type ParsedModelEntry = { spec: ModelSpec; maxWorkers?: number };
+
+function parseModelEntry(roleId: string, level: string, entry: ModelEntry): ParsedModelEntry {
+  if (typeof entry === "string") {
+    return { spec: entry };
+  }
+
+  if (entry && typeof entry === "object") {
+    const anyEntry = entry as Record<string, unknown>;
+    const maxWorkers = typeof anyEntry.maxWorkers === "number" ? anyEntry.maxWorkers : undefined;
+
+    if (isModelSpecObject(entry as ModelSpec)) {
+      const specObj = entry as ModelSpecObject;
+      return { spec: buildModelSpec(specObj.primary, specObj.fallbacks), maxWorkers };
+    }
+
+    if (anyEntry.model !== undefined) {
+      const modelValue = anyEntry.model;
+      if (typeof modelValue === "string") {
+        return { spec: buildModelSpec(modelValue, anyEntry.fallbacks as string[] | undefined), maxWorkers };
+      }
+      if (modelValue && typeof modelValue === "object") {
+        const modelObj = modelValue as ModelSpecObject;
+        return {
+          spec: buildModelSpec(modelObj.primary, modelObj.fallbacks, anyEntry.fallbacks as string[] | undefined),
+          maxWorkers,
+        };
+      }
+    }
+
+    if (typeof anyEntry.primary === "string") {
+      return {
+        spec: buildModelSpec(anyEntry.primary, anyEntry.fallbacks as string[] | undefined),
+        maxWorkers,
+      };
+    }
+  }
+
+  throw new Error(`Invalid model entry for ${roleId}.${level}: must specify a model or primary.`);
+}
+
+/** Flatten a ModelEntry map to normalized model specs. */
+function flattenModels(roleId: string, entries: Record<string, ModelEntry>): Record<string, ModelSpec> {
+  const flat: Record<string, ModelSpec> = {};
   for (const [level, entry] of Object.entries(entries)) {
-    flat[level] = typeof entry === "string" ? entry : entry.model;
+    const parsed = parseModelEntry(roleId, level, entry);
+    const normalized = normalizeModelSpec(parsed.spec);
+    flat[level] = normalized.fallbacks.length > 0
+      ? { primary: normalized.primary, fallbacks: normalized.fallbacks }
+      : normalized.primary;
   }
   return flat;
 }
 
 /** Resolve per-level maxWorkers from model entries + global default. */
 function resolveLevelMaxWorkers(
+  roleId: string,
   models: Record<string, ModelEntry>,
   globalDefault: number,
 ): Record<string, number> {
   const result: Record<string, number> = {};
   for (const [level, entry] of Object.entries(models)) {
-    if (typeof entry === "object" && entry.maxWorkers !== undefined) {
-      result[level] = entry.maxWorkers;
-    } else {
-      result[level] = globalDefault;
-    }
+    const parsed = parseModelEntry(roleId, level, entry);
+    result[level] = parsed.maxWorkers ?? globalDefault;
   }
   return result;
 }
@@ -130,10 +196,10 @@ function resolve(config: DevClawConfig): ResolvedConfig {
         const reg = ROLE_REGISTRY[id];
         const models: Record<string, ModelEntry> = reg ? { ...reg.models } : {};
         roles[id] = {
-          levelMaxWorkers: resolveLevelMaxWorkers(models, globalMaxWorkers),
+          levelMaxWorkers: resolveLevelMaxWorkers(id, models, globalMaxWorkers),
           levels: reg ? [...reg.levels] : [],
           defaultLevel: reg?.defaultLevel ?? "",
-          models: flattenModels(models),
+          models: flattenModels(id, models),
           emoji: reg ? { ...reg.emoji } : {},
           completionResults: reg ? [...reg.completionResults] : [],
           enabled: false,
@@ -147,10 +213,10 @@ function resolve(config: DevClawConfig): ResolvedConfig {
         ...(override.models ?? {}),
       };
       roles[id] = {
-        levelMaxWorkers: resolveLevelMaxWorkers(mergedModels, globalMaxWorkers),
+        levelMaxWorkers: resolveLevelMaxWorkers(id, mergedModels, globalMaxWorkers),
         levels: override.levels ?? (reg ? [...reg.levels] : []),
         defaultLevel: override.defaultLevel ?? reg?.defaultLevel ?? "",
-        models: flattenModels(mergedModels),
+        models: flattenModels(id, mergedModels),
         emoji: { ...(reg?.emoji ?? {}), ...(override.emoji ?? {}) },
         completionResults: override.completionResults ?? (reg ? [...reg.completionResults] : []),
         enabled: true,
@@ -163,10 +229,10 @@ function resolve(config: DevClawConfig): ResolvedConfig {
     if (!roles[id]) {
       const models: Record<string, ModelEntry> = { ...reg.models };
       roles[id] = {
-        levelMaxWorkers: resolveLevelMaxWorkers(models, globalMaxWorkers),
+        levelMaxWorkers: resolveLevelMaxWorkers(id, models, globalMaxWorkers),
         levels: [...reg.levels],
         defaultLevel: reg.defaultLevel,
-        models: flattenModels(models),
+        models: flattenModels(id, models),
         emoji: { ...reg.emoji },
         completionResults: [...reg.completionResults],
         enabled: true,

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -39,11 +39,21 @@ const WorkflowConfigSchema = z.object({
   states: z.record(z.string(), StateConfigSchema),
 });
 
+const ModelSpecObjectSchema = z.object({
+  primary: z.string(),
+  fallbacks: z.array(z.string()).optional(),
+});
+
 const ModelEntrySchema = z.union([
   z.string(),
+  ModelSpecObjectSchema,
   z.object({
-    model: z.string(),
+    model: z.union([z.string(), ModelSpecObjectSchema]).optional(),
+    primary: z.string().optional(),
+    fallbacks: z.array(z.string()).optional(),
     maxWorkers: z.number().int().positive().optional(),
+  }).refine((value) => value.model !== undefined || value.primary !== undefined || value.maxWorkers !== undefined, {
+    message: "Model entry must specify `model`, `primary`, or `maxWorkers`.",
   }),
 ]);
 

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -44,17 +44,12 @@ const ModelSpecObjectSchema = z.object({
   fallbacks: z.array(z.string()).optional(),
 });
 
-const ModelSpecWithMaxWorkersSchema = ModelSpecObjectSchema.extend({
-  maxWorkers: z.number().int().positive().optional(),
-});
+const StringModelOrModelSpec = z.union([z.string(), ModelSpecObjectSchema]);
 
 const ModelEntrySchema = z.union([
-  z.string(),
-  ModelSpecObjectSchema,
-  ModelSpecWithMaxWorkersSchema,
+  StringModelOrModelSpec,
   z.object({
-    model: z.union([z.string(), ModelSpecObjectSchema]),
-    fallbacks: z.array(z.string()).optional(),
+    model: StringModelOrModelSpec,
     maxWorkers: z.number().int().positive().optional(),
   }),
 ]);

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -44,16 +44,18 @@ const ModelSpecObjectSchema = z.object({
   fallbacks: z.array(z.string()).optional(),
 });
 
+const ModelSpecWithMaxWorkersSchema = ModelSpecObjectSchema.extend({
+  maxWorkers: z.number().int().positive().optional(),
+});
+
 const ModelEntrySchema = z.union([
   z.string(),
   ModelSpecObjectSchema,
+  ModelSpecWithMaxWorkersSchema,
   z.object({
-    model: z.union([z.string(), ModelSpecObjectSchema]).optional(),
-    primary: z.string().optional(),
+    model: z.union([z.string(), ModelSpecObjectSchema]),
     fallbacks: z.array(z.string()).optional(),
     maxWorkers: z.number().int().positive().optional(),
-  }).refine((value) => value.model !== undefined || value.primary !== undefined || value.maxWorkers !== undefined, {
-    message: "Model entry must specify `model`, `primary`, or `maxWorkers`.",
   }),
 ]);
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -14,14 +14,9 @@ import type { ModelSpec, ModelSpecObject } from "../roles/types.js";
 /** Model entry: string shorthand, structured spec, or legacy { model, maxWorkers } object. */
 export type ModelEntry =
   | string
-  | {
-      primary: string;
-      fallbacks?: string[];
-      maxWorkers?: number;
-    }
+  | ModelSpecObject
   | {
       model: string | ModelSpecObject;
-      fallbacks?: string[];
       maxWorkers?: number;
     };
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -5,13 +5,21 @@
  * Three-layer resolution: built-in → workspace → per-project.
  */
 import type { WorkflowConfig } from "../workflow/index.js";
+import type { ModelSpec, ModelSpecObject } from "../roles/types.js";
 
 /**
  * Role override in workflow.yaml. All fields optional — only override what you need.
  * Set to `false` to disable a role entirely for a project.
  */
-/** Model entry: plain string or object with per-level maxWorkers override. */
-export type ModelEntry = string | { model: string; maxWorkers?: number };
+/** Model entry: supports string specs, structured specs, and optional maxWorkers overrides. */
+export type ModelEntry =
+  | ModelSpec
+  | {
+      model?: string | ModelSpecObject;
+      primary?: string;
+      fallbacks?: string[];
+      maxWorkers?: number;
+    };
 
 export type RoleOverride = {
   maxWorkers?: number; // @deprecated — kept for backward compat, ignored by resolver
@@ -92,8 +100,8 @@ export type ResolvedRoleConfig = {
   levelMaxWorkers: Record<string, number>;
   levels: string[];
   defaultLevel: string;
-  /** Flattened model map (string IDs only, for existing consumers). */
-  models: Record<string, string>;
+  /** Flattened model map (string or structured specs, for existing consumers). */
+  models: Record<string, ModelSpec>;
   emoji: Record<string, string>;
   completionResults: string[];
   enabled: boolean;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -11,12 +11,16 @@ import type { ModelSpec, ModelSpecObject } from "../roles/types.js";
  * Role override in workflow.yaml. All fields optional — only override what you need.
  * Set to `false` to disable a role entirely for a project.
  */
-/** Model entry: supports string specs, structured specs, and optional maxWorkers overrides. */
+/** Model entry: string shorthand, structured spec, or legacy { model, maxWorkers } object. */
 export type ModelEntry =
-  | ModelSpec
+  | string
   | {
-      model?: string | ModelSpecObject;
-      primary?: string;
+      primary: string;
+      fallbacks?: string[];
+      maxWorkers?: number;
+    }
+  | {
+      model: string | ModelSpecObject;
       fallbacks?: string[];
       maxWorkers?: number;
     };

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -14,7 +14,7 @@ import {
   getRoleWorker,
   emptySlot,
 } from "../projects/index.js";
-import { resolveModel, normalizeModelSpec } from "../roles/index.js";
+import { resolveModel } from "../roles/index.js";
 import { notify, getNotificationConfig } from "./notify.js";
 import { loadConfig, type ResolvedRoleConfig } from "../config/index.js";
 import { ReviewPolicy, TestPolicy, resolveReviewRouting, resolveTestRouting, resolveNotifyChannel, isFeedbackState, hasReviewCheck, producesReviewableWork, hasTestPhase, detectOwner, getOwnerLabel, OWNER_LABEL_COLOR, getRoleLabelColor, STEP_ROUTING_COLOR, getStateLabels } from "../workflow/index.js";
@@ -98,9 +98,8 @@ export async function dispatchTask(
   const resolvedRole = resolvedConfig.roles[role];
   const { timeouts } = resolvedConfig;
   const modelSpec = resolveModel(role, level, resolvedRole);
-  const normalizedModel = normalizeModelSpec(modelSpec);
-  const primaryModel = normalizedModel.primary;
-  const fallbackModels = normalizedModel.fallbacks;
+  const primaryModel = modelSpec.primary;
+  const fallbackModels = modelSpec.fallbacks;
   const roleWorker = getRoleWorker(project, role);
   const slot = roleWorker.levels[level]?.[slotIndex] ?? emptySlot();
   let existingSessionKey = slot.sessionKey;

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -14,7 +14,7 @@ import {
   getRoleWorker,
   emptySlot,
 } from "../projects/index.js";
-import { resolveModel } from "../roles/index.js";
+import { resolveModel, normalizeModelSpec } from "../roles/index.js";
 import { notify, getNotificationConfig } from "./notify.js";
 import { loadConfig, type ResolvedRoleConfig } from "../config/index.js";
 import { ReviewPolicy, TestPolicy, resolveReviewRouting, resolveTestRouting, resolveNotifyChannel, isFeedbackState, hasReviewCheck, producesReviewableWork, hasTestPhase, detectOwner, getOwnerLabel, OWNER_LABEL_COLOR, getRoleLabelColor, STEP_ROUTING_COLOR, getStateLabels } from "../workflow/index.js";
@@ -63,6 +63,7 @@ export type DispatchResult = {
   sessionKey: string;
   level: string;
   model: string;
+  fallbacks?: string[];
   announcement: string;
 };
 
@@ -96,7 +97,10 @@ export async function dispatchTask(
   const resolvedConfig = await loadConfig(workspaceDir, project.name);
   const resolvedRole = resolvedConfig.roles[role];
   const { timeouts } = resolvedConfig;
-  const model = resolveModel(role, level, resolvedRole);
+  const modelSpec = resolveModel(role, level, resolvedRole);
+  const normalizedModel = normalizeModelSpec(modelSpec);
+  const primaryModel = normalizedModel.primary;
+  const fallbackModels = normalizedModel.fallbacks;
   const roleWorker = getRoleWorker(project, role);
   const slot = roleWorker.levels[level]?.[slotIndex] ?? emptySlot();
   let existingSessionKey = slot.sessionKey;
@@ -260,6 +264,8 @@ export async function dispatchTask(
       level,
       name: botName,
       sessionAction,
+      model: primaryModel,
+      fallbacks: fallbackModels.length > 0 ? fallbackModels : undefined,
     },
     {
       workspaceDir,
@@ -280,7 +286,7 @@ export async function dispatchTask(
   // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
   // Session key is deterministic, so we can proceed immediately
   const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(sessionKey, model, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel);
+  ensureSessionFireAndForget(sessionKey, primaryModel, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel, fallbackModels);
 
   // Step 4: Send task to agent (fire-and-forget)
   // Model is set on the session via sessions.patch (step 3), not on the agent RPC —
@@ -310,13 +316,21 @@ export async function dispatchTask(
   // Step 6: Audit
   await auditDispatch(workspaceDir, {
     project: project.name, issueId, issueTitle,
-    role, level, model, sessionAction, sessionKey,
+    role, level, model: primaryModel, fallbacks: fallbackModels,
+    sessionAction, sessionKey,
     fromLabel, toLabel,
   });
 
   const announcement = buildAnnouncement(level, role, sessionAction, issueId, issueTitle, issueUrl, resolvedRole, botName);
 
-  return { sessionAction, sessionKey, level, model, announcement };
+  return {
+    sessionAction,
+    sessionKey,
+    level,
+    model: primaryModel,
+    fallbacks: fallbackModels.length > 0 ? fallbackModels : undefined,
+    announcement,
+  };
 }
 
 async function recordWorkerState(
@@ -346,7 +360,7 @@ async function auditDispatch(
   workspaceDir: string,
   opts: {
     project: string; issueId: number; issueTitle: string;
-    role: string; level: string; model: string; sessionAction: string;
+    role: string; level: string; model: string; fallbacks?: string[]; sessionAction: string;
     sessionKey: string; fromLabel: string; toLabel: string;
   },
 ): Promise<void> {
@@ -357,8 +371,15 @@ async function auditDispatch(
     sessionAction: opts.sessionAction, sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
   });
+  const fallbackEntry = opts.fallbacks && opts.fallbacks.length > 0
+    ? { fallbacks: opts.fallbacks }
+    : {};
   await auditLog(workspaceDir, "model_selection", {
-    issue: opts.issueId, role: opts.role, level: opts.level, model: opts.model,
+    issue: opts.issueId,
+    role: opts.role,
+    level: opts.level,
+    model: opts.model,
+    ...fallbackEntry,
   });
 }
 

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -15,6 +15,7 @@ import {
   emptySlot,
 } from "../projects/index.js";
 import { resolveModel } from "../roles/index.js";
+import type { ModelSpec } from "../roles/index.js";
 import { notify, getNotificationConfig } from "./notify.js";
 import { loadConfig, type ResolvedRoleConfig } from "../config/index.js";
 import { ReviewPolicy, TestPolicy, resolveReviewRouting, resolveTestRouting, resolveNotifyChannel, isFeedbackState, hasReviewCheck, producesReviewableWork, hasTestPhase, detectOwner, getOwnerLabel, OWNER_LABEL_COLOR, getRoleLabelColor, STEP_ROUTING_COLOR, getStateLabels } from "../workflow/index.js";
@@ -62,8 +63,7 @@ export type DispatchResult = {
   sessionAction: "spawn" | "send";
   sessionKey: string;
   level: string;
-  model: string;
-  fallbacks?: string[];
+  model: ModelSpec;
   announcement: string;
 };
 
@@ -99,7 +99,6 @@ export async function dispatchTask(
   const { timeouts } = resolvedConfig;
   const modelSpec = resolveModel(role, level, resolvedRole);
   const primaryModel = modelSpec.primary;
-  const fallbackModels = modelSpec.fallbacks;
   const roleWorker = getRoleWorker(project, role);
   const slot = roleWorker.levels[level]?.[slotIndex] ?? emptySlot();
   let existingSessionKey = slot.sessionKey;
@@ -263,8 +262,7 @@ export async function dispatchTask(
       level,
       name: botName,
       sessionAction,
-      model: primaryModel,
-      fallbacks: fallbackModels.length > 0 ? fallbackModels : undefined,
+      model: modelSpec,
     },
     {
       workspaceDir,
@@ -285,7 +283,7 @@ export async function dispatchTask(
   // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
   // Session key is deterministic, so we can proceed immediately
   const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(sessionKey, primaryModel, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel, fallbackModels);
+  ensureSessionFireAndForget(sessionKey, modelSpec, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel);
 
   // Step 4: Send task to agent (fire-and-forget)
   // Model is set on the session via sessions.patch (step 3), not on the agent RPC —
@@ -315,7 +313,7 @@ export async function dispatchTask(
   // Step 6: Audit
   await auditDispatch(workspaceDir, {
     project: project.name, issueId, issueTitle,
-    role, level, model: primaryModel, fallbacks: fallbackModels,
+    role, level, model: modelSpec,
     sessionAction, sessionKey,
     fromLabel, toLabel,
   });
@@ -326,8 +324,7 @@ export async function dispatchTask(
     sessionAction,
     sessionKey,
     level,
-    model: primaryModel,
-    fallbacks: fallbackModels.length > 0 ? fallbackModels : undefined,
+    model: modelSpec,
     announcement,
   };
 }
@@ -359,7 +356,7 @@ async function auditDispatch(
   workspaceDir: string,
   opts: {
     project: string; issueId: number; issueTitle: string;
-    role: string; level: string; model: string; fallbacks?: string[]; sessionAction: string;
+    role: string; level: string; model: ModelSpec; sessionAction: string;
     sessionKey: string; fromLabel: string; toLabel: string;
   },
 ): Promise<void> {
@@ -370,15 +367,12 @@ async function auditDispatch(
     sessionAction: opts.sessionAction, sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
   });
-  const fallbackEntry = opts.fallbacks && opts.fallbacks.length > 0
-    ? { fallbacks: opts.fallbacks }
-    : {};
   await auditLog(workspaceDir, "model_selection", {
     issue: opts.issueId,
     role: opts.role,
     level: opts.level,
-    model: opts.model,
-    ...fallbackEntry,
+    model: opts.model.primary,
+    fallbacks: opts.model.fallbacks,
   });
 }
 

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -13,6 +13,7 @@ import { log as auditLog } from "../audit.js";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import type { ModelSpec } from "../roles/index.js";
+import { modelSpecToString } from "../roles/index.js";
 
 /** Per-event-type toggle. All default to true — set to false to suppress. */
 export type NotificationConfig = Partial<Record<NotifyEvent["type"], boolean>>;
@@ -152,7 +153,8 @@ function buildMessage(event: NotifyEvent): string {
         name: event.name,
         level: event.level,
       });
-      return `${action} ${worker} on #${event.issueId}: ${event.issueTitle}\n🔗 [Issue #${event.issueId}](${event.issueUrl})`;
+      const modelLine = event.model ? `\n🧠 Model: ${modelSpecToString(event.model)}` : "";
+      return `${action} ${worker} on #${event.issueId}: ${event.issueTitle}${modelLine}\n🔗 [Issue #${event.issueId}](${event.issueUrl})`;
     }
 
     case "workerComplete": {

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -12,6 +12,7 @@
 import { log as auditLog } from "../audit.js";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
+import type { ModelSpec } from "../roles/index.js";
 
 /** Per-event-type toggle. All default to true — set to false to suppress. */
 export type NotificationConfig = Partial<Record<NotifyEvent["type"], boolean>>;
@@ -27,8 +28,7 @@ export type NotifyEvent =
       level: string;
       name?: string;
       sessionAction: "spawn" | "send";
-      model?: string;
-      fallbacks?: string[];
+      model?: ModelSpec;
     }
   | {
       type: "workerComplete";

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -27,6 +27,8 @@ export type NotifyEvent =
       level: string;
       name?: string;
       sessionAction: "spawn" | "send";
+      model?: string;
+      fallbacks?: string[];
     }
   | {
       type: "workerComplete";

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -70,18 +70,36 @@ export async function shouldClearSession(
  */
 export function ensureSessionFireAndForget(sessionKey: string, model: ModelSpec, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string): void {
   const rc = runCommand;
-  const params: Record<string, unknown> = { key: sessionKey, model: model.primary };
-  if (model.fallbacks.length > 0) params.fallbacks = model.fallbacks;
-  if (label) params.label = label;
-  rc(
-    ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],
-    { timeoutMs },
-  ).catch((err) => {
-    auditLog(workspaceDir, "dispatch_warning", {
-      step: "ensureSession", sessionKey,
-      error: (err as Error).message ?? String(err),
-    }).catch(() => {});
-  });
+  const candidates = [model.primary, ...model.fallbacks];
+
+  const attempt = (index: number) => {
+    const params: Record<string, unknown> = { key: sessionKey, model: candidates[index] };
+    if (label) params.label = label;
+
+    rc(
+      ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],
+      { timeoutMs },
+    ).catch((err) => {
+      const message = (err as Error).message ?? String(err);
+      if (isTransientModelError(message) && index + 1 < candidates.length) {
+        attempt(index + 1);
+        return;
+      }
+
+      auditLog(workspaceDir, "dispatch_warning", {
+        step: "ensureSession",
+        sessionKey,
+        error: message,
+      }).catch(() => {});
+    });
+  };
+
+  attempt(0);
+}
+
+function isTransientModelError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return lower.includes("429") || lower.includes("too many requests") || lower.includes("temporar") || lower.includes("503");
 }
 
 export function sendToAgent(

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -4,6 +4,7 @@
 import type { RunCommand } from "../context.js";
 import { log as auditLog } from "../audit.js";
 import { fetchGatewaySessions } from "../services/gateway-sessions.js";
+import type { ModelSpec } from "../roles/index.js";
 
 // ---------------------------------------------------------------------------
 // Context budget management
@@ -67,10 +68,10 @@ export async function shouldClearSession(
  * Session key is deterministic, so we don't need to wait for confirmation.
  * If this fails, health check will catch orphaned state later.
  */
-export function ensureSessionFireAndForget(sessionKey: string, model: string, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string, fallbacks?: string[]): void {
+export function ensureSessionFireAndForget(sessionKey: string, model: ModelSpec, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string): void {
   const rc = runCommand;
-  const params: Record<string, unknown> = { key: sessionKey, model };
-  if (fallbacks && fallbacks.length > 0) params.fallbacks = fallbacks;
+  const params: Record<string, unknown> = { key: sessionKey, model: model.primary };
+  if (model.fallbacks.length > 0) params.fallbacks = model.fallbacks;
   if (label) params.label = label;
   rc(
     ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -67,9 +67,10 @@ export async function shouldClearSession(
  * Session key is deterministic, so we don't need to wait for confirmation.
  * If this fails, health check will catch orphaned state later.
  */
-export function ensureSessionFireAndForget(sessionKey: string, model: string, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string): void {
+export function ensureSessionFireAndForget(sessionKey: string, model: string, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string, fallbacks?: string[]): void {
   const rc = runCommand;
   const params: Record<string, unknown> = { key: sessionKey, model };
+  if (fallbacks && fallbacks.length > 0) params.fallbacks = fallbacks;
   if (label) params.label = label;
   rc(
     ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],

--- a/lib/roles/index.ts
+++ b/lib/roles/index.ts
@@ -5,7 +5,7 @@
  * To add a new role, add an entry to registry.ts — everything else derives from it.
  */
 export { ROLE_REGISTRY } from "./registry.js";
-export type { RoleConfig, ModelSpec, ModelSpecObject } from "./types.js";
+export type { RoleConfig, ModelSpec, ModelSpecObject, ModelSpecInput } from "./types.js";
 export { normalizeModelSpec, getModelPrimary, getModelFallbacks, isModelSpecObject } from "./types.js";
 export {
   // Role IDs

--- a/lib/roles/index.ts
+++ b/lib/roles/index.ts
@@ -6,7 +6,7 @@
  */
 export { ROLE_REGISTRY } from "./registry.js";
 export type { RoleConfig, ModelSpec, ModelSpecObject, ModelSpecInput } from "./types.js";
-export { normalizeModelSpec, getModelPrimary, getModelFallbacks, isModelSpecObject } from "./types.js";
+export { normalizeModelSpec, getModelPrimary, getModelFallbacks, isModelSpecObject, modelSpecToString } from "./types.js";
 export {
   // Role IDs
   getAllRoleIds,

--- a/lib/roles/index.ts
+++ b/lib/roles/index.ts
@@ -5,7 +5,8 @@
  * To add a new role, add an entry to registry.ts — everything else derives from it.
  */
 export { ROLE_REGISTRY } from "./registry.js";
-export type { RoleConfig } from "./types.js";
+export type { RoleConfig, ModelSpec, ModelSpecObject } from "./types.js";
+export { normalizeModelSpec, getModelPrimary, getModelFallbacks, isModelSpecObject } from "./types.js";
 export {
   // Role IDs
   getAllRoleIds,

--- a/lib/roles/registry.test.ts
+++ b/lib/roles/registry.test.ts
@@ -24,6 +24,7 @@ import {
   getCompletionResults,
   isValidResult,
   getSessionKeyRolePattern,
+  normalizeModelSpec,
 } from "./index.js";
 
 describe("role registry", () => {
@@ -169,6 +170,24 @@ describe("models", () => {
     assert.strictEqual(resolveModel("developer", "junior", resolvedRole), "custom/model");
     // Levels not overridden fall through to registry defaults
     assert.strictEqual(resolveModel("developer", "medior", resolvedRole), "anthropic/claude-sonnet-4-5");
+  });
+
+  it("should normalize fallback chains when provided", () => {
+    const resolvedRole = {
+      levelMaxWorkers: { junior: 2, medior: 2, senior: 2 },
+      models: { medior: { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5-codex"] } },
+      levels: ["junior", "medior", "senior"],
+      defaultLevel: "medior",
+      emoji: {},
+      completionResults: [] as string[],
+      enabled: true,
+    };
+    const spec = resolveModel("developer", "medior", resolvedRole);
+    const normalized = normalizeModelSpec(spec);
+    assert.deepStrictEqual(normalized, {
+      primary: "anthropic/claude-sonnet-4-6",
+      fallbacks: ["openai/gpt-5-codex"],
+    });
   });
 });
 

--- a/lib/roles/registry.test.ts
+++ b/lib/roles/registry.test.ts
@@ -145,37 +145,62 @@ describe("models", () => {
   });
 
   it("should resolve from resolved role config override", () => {
-    const resolvedRole = { levelMaxWorkers: { junior: 2, medior: 2, senior: 2 }, models: { junior: "custom/model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
-    assert.strictEqual(resolveModel("developer", "junior", resolvedRole), "custom/model");
+    const resolvedRole = {
+      levelMaxWorkers: { junior: 2, medior: 2, senior: 2 },
+      models: { junior: normalizeModelSpec("custom/model") },
+      levels: ["junior", "medior", "senior"],
+      defaultLevel: "medior",
+      emoji: {},
+      completionResults: [] as string[],
+      enabled: true,
+    };
+    assert.strictEqual(resolveModel("developer", "junior", resolvedRole).primary, "custom/model");
   });
 
   it("should fall back to default", () => {
-    assert.strictEqual(resolveModel("developer", "junior"), "anthropic/claude-haiku-4-5");
+    assert.strictEqual(resolveModel("developer", "junior").primary, "anthropic/claude-haiku-4-5");
   });
 
   it("should pass through unknown level as model ID", () => {
-    assert.strictEqual(resolveModel("developer", "anthropic/claude-opus-4-6"), "anthropic/claude-opus-4-6");
+    const spec = resolveModel("developer", "anthropic/claude-opus-4-6");
+    assert.deepStrictEqual(spec, { primary: "anthropic/claude-opus-4-6", fallbacks: [] });
   });
 
   it("should resolve via level aliases", () => {
     // "mid" alias maps to "medior" — should resolve to default medior model
-    assert.strictEqual(resolveModel("developer", "mid"), "anthropic/claude-sonnet-4-5");
+    assert.strictEqual(resolveModel("developer", "mid").primary, "anthropic/claude-sonnet-4-5");
     // With explicit override in resolved config
-    const resolvedRole = { levelMaxWorkers: { junior: 2, medior: 2, senior: 2 }, models: { medior: "custom/old-config-model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
-    assert.strictEqual(resolveModel("developer", "mid", resolvedRole), "custom/old-config-model");
+    const resolvedRole = {
+      levelMaxWorkers: { junior: 2, medior: 2, senior: 2 },
+      models: { medior: normalizeModelSpec("custom/old-config-model") },
+      levels: ["junior", "medior", "senior"],
+      defaultLevel: "medior",
+      emoji: {},
+      completionResults: [] as string[],
+      enabled: true,
+    };
+    assert.strictEqual(resolveModel("developer", "mid", resolvedRole).primary, "custom/old-config-model");
   });
 
   it("should resolve with resolved role overriding defaults selectively", () => {
-    const resolvedRole = { levelMaxWorkers: { junior: 2, medior: 2, senior: 2 }, models: { junior: "custom/model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
-    assert.strictEqual(resolveModel("developer", "junior", resolvedRole), "custom/model");
+    const resolvedRole = {
+      levelMaxWorkers: { junior: 2, medior: 2, senior: 2 },
+      models: { junior: normalizeModelSpec("custom/model") },
+      levels: ["junior", "medior", "senior"],
+      defaultLevel: "medior",
+      emoji: {},
+      completionResults: [] as string[],
+      enabled: true,
+    };
+    assert.strictEqual(resolveModel("developer", "junior", resolvedRole).primary, "custom/model");
     // Levels not overridden fall through to registry defaults
-    assert.strictEqual(resolveModel("developer", "medior", resolvedRole), "anthropic/claude-sonnet-4-5");
+    assert.strictEqual(resolveModel("developer", "medior", resolvedRole).primary, "anthropic/claude-sonnet-4-5");
   });
 
   it("should normalize fallback chains when provided", () => {
     const resolvedRole = {
       levelMaxWorkers: { junior: 2, medior: 2, senior: 2 },
-      models: { medior: { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5-codex"] } },
+      models: { medior: normalizeModelSpec({ primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5-codex"] }) },
       levels: ["junior", "medior", "senior"],
       defaultLevel: "medior",
       emoji: {},
@@ -183,8 +208,7 @@ describe("models", () => {
       enabled: true,
     };
     const spec = resolveModel("developer", "medior", resolvedRole);
-    const normalized = normalizeModelSpec(spec);
-    assert.deepStrictEqual(normalized, {
+    assert.deepStrictEqual(spec, {
       primary: "anthropic/claude-sonnet-4-6",
       fallbacks: ["openai/gpt-5-codex"],
     });

--- a/lib/roles/selectors.ts
+++ b/lib/roles/selectors.ts
@@ -5,7 +5,8 @@
  * No other file should access ROLE_REGISTRY directly for role logic.
  */
 import { ROLE_REGISTRY } from "./registry.js";
-import type { RoleConfig, ModelSpec } from "./types.js";
+import { normalizeModelSpec } from "./types.js";
+import type { RoleConfig, ModelSpec, ModelSpecInput } from "./types.js";
 import type { ResolvedRoleConfig } from "../config/types.js";
 import { ROLE_ALIASES as _ROLE_ALIASES, canonicalLevel as _canonicalLevel } from "../projects/migrations.js";
 
@@ -82,12 +83,13 @@ export function getDefaultLevel(role: string): string | undefined {
 
 /** Get default model for a role + level. */
 export function getDefaultModel(role: string, level: string): ModelSpec | undefined {
-  return getRole(role)?.models[level];
+  const raw = getRole(role)?.models[level];
+  return raw !== undefined ? normalizeModelSpec(raw) : undefined;
 }
 
-/** Get all default models, nested by role (for config schema). */
-export function getAllDefaultModels(): Record<string, Record<string, ModelSpec>> {
-  const result: Record<string, Record<string, ModelSpec>> = {};
+/** Get all default models, nested by role (for config schema/display). */
+export function getAllDefaultModels(): Record<string, Record<string, ModelSpecInput>> {
+  const result: Record<string, Record<string, ModelSpecInput>> = {};
   for (const [roleId, config] of Object.entries(ROLE_REGISTRY)) {
     result[roleId] = { ...config.models };
   }
@@ -115,7 +117,10 @@ export function resolveModel(
 
   // 2. Built-in registry default
   const fallback = getDefaultModel(role, canonical);
-  return fallback ?? canonical;
+  if (fallback) return fallback;
+
+  // 3. Passthrough (use canonical level name as primary model)
+  return normalizeModelSpec(canonical);
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/roles/selectors.ts
+++ b/lib/roles/selectors.ts
@@ -5,7 +5,7 @@
  * No other file should access ROLE_REGISTRY directly for role logic.
  */
 import { ROLE_REGISTRY } from "./registry.js";
-import type { RoleConfig } from "./types.js";
+import type { RoleConfig, ModelSpec } from "./types.js";
 import type { ResolvedRoleConfig } from "../config/types.js";
 import { ROLE_ALIASES as _ROLE_ALIASES, canonicalLevel as _canonicalLevel } from "../projects/migrations.js";
 
@@ -81,13 +81,13 @@ export function getDefaultLevel(role: string): string | undefined {
 // ---------------------------------------------------------------------------
 
 /** Get default model for a role + level. */
-export function getDefaultModel(role: string, level: string): string | undefined {
+export function getDefaultModel(role: string, level: string): ModelSpec | undefined {
   return getRole(role)?.models[level];
 }
 
 /** Get all default models, nested by role (for config schema). */
-export function getAllDefaultModels(): Record<string, Record<string, string>> {
-  const result: Record<string, Record<string, string>> = {};
+export function getAllDefaultModels(): Record<string, Record<string, ModelSpec>> {
+  const result: Record<string, Record<string, ModelSpec>> = {};
   for (const [roleId, config] of Object.entries(ROLE_REGISTRY)) {
     result[roleId] = { ...config.models };
   }
@@ -95,7 +95,7 @@ export function getAllDefaultModels(): Record<string, Record<string, string>> {
 }
 
 /**
- * Resolve a level to a full model ID.
+ * Resolve a level to a model specification.
  *
  * Resolution order:
  * 1. Resolved config from workflow.yaml (three-layer merge)
@@ -106,14 +106,16 @@ export function resolveModel(
   role: string,
   level: string,
   resolvedRole?: ResolvedRoleConfig,
-): string {
+): ModelSpec {
   const canonical = _canonicalLevel(role, level);
 
   // 1. Resolved config (workflow.yaml — includes workspace + project overrides)
-  if (resolvedRole?.models[canonical]) return resolvedRole.models[canonical];
+  const override = resolvedRole?.models[canonical];
+  if (override !== undefined) return override;
 
   // 2. Built-in registry default
-  return getDefaultModel(role, canonical) ?? canonical;
+  const fallback = getDefaultModel(role, canonical);
+  return fallback ?? canonical;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/roles/smart-model-selector.ts
+++ b/lib/roles/smart-model-selector.ts
@@ -3,7 +3,7 @@
  *
  * Uses an LLM to intelligently analyze and assign models to DevClaw roles.
  */
-import { getAllRoleIds, getLevelsForRole } from "./index.js";
+import { getAllRoleIds, getLevelsForRole, normalizeModelSpec } from "./index.js";
 import { ROLE_REGISTRY } from "./index.js";
 import type { RunCommand } from "../context.js";
 
@@ -68,9 +68,10 @@ export async function assignModels(
   for (const [roleId, config] of Object.entries(ROLE_REGISTRY)) {
     result[roleId] = {};
     for (const level of config.levels) {
-      const registryDefault = config.models[level];
-      result[roleId][level] = registryDefault && modelSet.has(registryDefault)
-        ? registryDefault
+      const registrySpec = config.models[level];
+      const registryPrimary = registrySpec ? normalizeModelSpec(registrySpec).primary : undefined;
+      result[roleId][level] = registryPrimary && modelSet.has(registryPrimary)
+        ? registryPrimary
         : fallback;
     }
   }

--- a/lib/roles/types.ts
+++ b/lib/roles/types.ts
@@ -5,41 +5,52 @@
  * All role-related behavior should be derived from this config.
  */
 
-/** Structured model specification with optional fallbacks. */
+/** Structured model specification with optional fallbacks (input form). */
 export type ModelSpecObject = {
   primary: string;
   fallbacks?: string[];
 };
 
-/** Model specification accepted by the registry and selectors. */
-export type ModelSpec = string | ModelSpecObject;
+/** Normalized model specification used throughout the runtime. */
+export type ModelSpec = {
+  primary: string;
+  fallbacks: string[];
+};
 
-/** Determine whether a model spec is an object with primary/fallbacks. */
-export function isModelSpecObject(spec: ModelSpec): spec is ModelSpecObject {
+/** Accepts string or object input when normalizing. */
+export type ModelSpecInput = string | ModelSpecObject | ModelSpec;
+
+/** Determine whether a value is a structured model spec input. */
+export function isModelSpecObject(spec: unknown): spec is ModelSpecObject {
   return typeof spec === "object" && spec !== null && "primary" in spec;
 }
 
 /**
- * Normalize a model spec into a primary model plus fallbacks array.
+ * Normalize a model spec into `{ primary, fallbacks[] }`.
  * Returns a shallow copy so callers can mutate the fallback list safely.
  */
-export function normalizeModelSpec(spec: ModelSpec): { primary: string; fallbacks: string[] } {
-  if (isModelSpecObject(spec)) {
-    const fallbacks = Array.isArray(spec.fallbacks)
-      ? spec.fallbacks.filter((f): f is string => typeof f === "string")
-      : [];
-    return { primary: spec.primary, fallbacks: [...fallbacks] };
+export function normalizeModelSpec(spec: ModelSpecInput): ModelSpec {
+  if (typeof spec === "string") {
+    return { primary: spec, fallbacks: [] };
   }
-  return { primary: spec, fallbacks: [] };
+
+  const fallbacksSource = Array.isArray((spec as ModelSpecObject).fallbacks)
+    ? (spec as ModelSpecObject).fallbacks!
+    : Array.isArray((spec as ModelSpec).fallbacks)
+      ? (spec as ModelSpec).fallbacks
+      : [];
+
+  const fallbacks = fallbacksSource.filter((f): f is string => typeof f === "string");
+  return { primary: spec.primary, fallbacks: [...new Set(fallbacks)] };
 }
 
 /** Get the primary model ID for a model spec. */
-export function getModelPrimary(spec: ModelSpec): string {
+export function getModelPrimary(spec: ModelSpecInput): string {
   return normalizeModelSpec(spec).primary;
 }
 
 /** Get the fallback model IDs for a model spec. */
-export function getModelFallbacks(spec: ModelSpec): string[] {
+export function getModelFallbacks(spec: ModelSpecInput): string[] {
   return normalizeModelSpec(spec).fallbacks;
 }
 
@@ -54,7 +65,7 @@ export type RoleConfig = {
   /** Default level when none specified. */
   defaultLevel: string;
   /** Default model per level. */
-  models: Record<string, ModelSpec>;
+  models: Record<string, ModelSpecInput>;
   /** Emoji per level (used in announcements). */
   emoji: Record<string, string>;
   /** Fallback emoji when level-specific emoji not found. */

--- a/lib/roles/types.ts
+++ b/lib/roles/types.ts
@@ -54,6 +54,13 @@ export function getModelFallbacks(spec: ModelSpecInput): string[] {
   return normalizeModelSpec(spec).fallbacks;
 }
 
+/** Render a model spec as a human-readable string. */
+export function modelSpecToString(spec: ModelSpec): string {
+  return spec.fallbacks.length > 0
+    ? `${spec.primary} (fallbacks: ${spec.fallbacks.join(", ")})`
+    : spec.primary;
+}
+
 /** Configuration for a single worker role. */
 export type RoleConfig = {
   /** Unique role identifier (e.g., "developer", "tester", "architect"). */

--- a/lib/roles/types.ts
+++ b/lib/roles/types.ts
@@ -5,6 +5,44 @@
  * All role-related behavior should be derived from this config.
  */
 
+/** Structured model specification with optional fallbacks. */
+export type ModelSpecObject = {
+  primary: string;
+  fallbacks?: string[];
+};
+
+/** Model specification accepted by the registry and selectors. */
+export type ModelSpec = string | ModelSpecObject;
+
+/** Determine whether a model spec is an object with primary/fallbacks. */
+export function isModelSpecObject(spec: ModelSpec): spec is ModelSpecObject {
+  return typeof spec === "object" && spec !== null && "primary" in spec;
+}
+
+/**
+ * Normalize a model spec into a primary model plus fallbacks array.
+ * Returns a shallow copy so callers can mutate the fallback list safely.
+ */
+export function normalizeModelSpec(spec: ModelSpec): { primary: string; fallbacks: string[] } {
+  if (isModelSpecObject(spec)) {
+    const fallbacks = Array.isArray(spec.fallbacks)
+      ? spec.fallbacks.filter((f): f is string => typeof f === "string")
+      : [];
+    return { primary: spec.primary, fallbacks: [...fallbacks] };
+  }
+  return { primary: spec, fallbacks: [] };
+}
+
+/** Get the primary model ID for a model spec. */
+export function getModelPrimary(spec: ModelSpec): string {
+  return normalizeModelSpec(spec).primary;
+}
+
+/** Get the fallback model IDs for a model spec. */
+export function getModelFallbacks(spec: ModelSpec): string[] {
+  return normalizeModelSpec(spec).fallbacks;
+}
+
 /** Configuration for a single worker role. */
 export type RoleConfig = {
   /** Unique role identifier (e.g., "developer", "tester", "architect"). */
@@ -16,7 +54,7 @@ export type RoleConfig = {
   /** Default level when none specified. */
   defaultLevel: string;
   /** Default model per level. */
-  models: Record<string, string>;
+  models: Record<string, ModelSpec>;
   /** Emoji per level (used in announcements). */
   emoji: Record<string, string>;
   /** Fallback emoji when level-specific emoji not found. */

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -10,6 +10,8 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { createTestHarness, type TestHarness } from "../testing/index.js";
 import { dispatchTask } from "../dispatch/index.js";
 import { executeCompletion } from "./pipeline.js";
@@ -117,6 +119,55 @@ describe("E2E pipeline", () => {
       assert.ok(patches.length > 0, "Should have patched session");
       assert.strictEqual(patches[0].model, result.model,
         `Session patch model should match: expected ${result.model}, got ${patches[0].model}`);
+    });
+
+    it("should propagate fallback chains to session patch and audit log", async () => {
+      await fs.mkdir(path.join(h.workspaceDir, "devclaw"), { recursive: true });
+      await fs.writeFile(
+        path.join(h.workspaceDir, "devclaw", "workflow.yaml"),
+        `roles:\n  developer:\n    models:\n      medior:\n        primary: anthropic/claude-sonnet-4-6\n        fallbacks:\n          - openai/gpt-5-codex\n          - anthropic/claude-haiku-4-5\n`,
+        "utf-8",
+      );
+
+      const issueId = 137;
+      h.provider.seedIssue({ iid: issueId, title: "Fallback test", labels: ["To Do"] });
+
+      const result = await dispatchTask({
+        workspaceDir: h.workspaceDir,
+        agentId: "test-agent",
+        project: h.project,
+        issueId,
+        issueTitle: "Fallback test",
+        issueDescription: "Ensure fallback chain propagates",
+        issueUrl: "https://example.com/issues/137",
+        role: "developer",
+        level: "medior",
+        fromLabel: "To Do",
+        toLabel: "Doing",
+        provider: h.provider,
+        runCommand: h.runCommand,
+      });
+
+      assert.deepStrictEqual(result.fallbacks, [
+        "openai/gpt-5-codex",
+        "anthropic/claude-haiku-4-5",
+      ]);
+
+      const patches = h.commands.sessionPatches();
+      assert.ok(patches.length > 0, "Should have patched session with fallback chain");
+      assert.deepStrictEqual(patches[0].fallbacks, result.fallbacks);
+
+      const auditPath = path.join(h.workspaceDir, "devclaw", "log", "audit.log");
+      const logContent = await fs.readFile(auditPath, "utf-8");
+      const modelSelection = logContent
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+        .reverse()
+        .find((entry) => entry.event === "model_selection" && entry.issue === issueId);
+
+      assert.ok(modelSelection, "Expected model_selection audit entry");
+      assert.deepStrictEqual(modelSelection.fallbacks, result.fallbacks);
     });
 
     it("should include comments in task message", async () => {

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -125,7 +125,7 @@ describe("E2E pipeline", () => {
       await fs.mkdir(path.join(h.workspaceDir, "devclaw"), { recursive: true });
       await fs.writeFile(
         path.join(h.workspaceDir, "devclaw", "workflow.yaml"),
-        `roles:\n  developer:\n    models:\n      medior:\n        primary: anthropic/claude-sonnet-4-6\n        fallbacks:\n          - openai/gpt-5-codex\n          - anthropic/claude-haiku-4-5\n`,
+        `roles:\n  developer:\n    models:\n      medior:\n        model:\n          primary: anthropic/claude-sonnet-4-6\n          fallbacks:\n            - openai/gpt-5-codex\n            - anthropic/claude-haiku-4-5\n`,
         "utf-8",
       );
 

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -108,7 +108,8 @@ describe("E2E pipeline", () => {
       });
 
       // Model should be resolved and returned
-      assert.ok(result.model, "dispatch should return a model");
+      assert.ok(result.model, "dispatch should return a model spec");
+      assert.strictEqual(result.model.primary, "anthropic/claude-sonnet-4-5");
 
       // Model must NOT be passed to the agent RPC (gateway rejects unknown props)
       const agentModels = h.commands.agentModels();
@@ -117,8 +118,8 @@ describe("E2E pipeline", () => {
       // Model is set on the session via sessions.patch instead
       const patches = h.commands.sessionPatches();
       assert.ok(patches.length > 0, "Should have patched session");
-      assert.strictEqual(patches[0].model, result.model,
-        `Session patch model should match: expected ${result.model}, got ${patches[0].model}`);
+      assert.strictEqual(patches[0].model, result.model.primary,
+        `Session patch model should match: expected ${result.model.primary}, got ${patches[0].model}`);
     });
 
     it("should propagate fallback chains to session patch and audit log", async () => {

--- a/lib/setup/cli.ts
+++ b/lib/setup/cli.ts
@@ -7,7 +7,8 @@ import type { Command } from "commander";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../context.js";
 import { runSetup } from "./index.js";
-import { getAllDefaultModels, getAllRoleIds, getLevelsForRole } from "../roles/index.js";
+import { getAllDefaultModels, getAllRoleIds, getLevelsForRole, normalizeModelSpec } from "../roles/index.js";
+import type { ModelSpec } from "../roles/index.js";
 import { readProjects, writeProjects, type Channel } from "../projects/index.js";
 import { log as auditLog } from "../audit.js";
 
@@ -43,7 +44,10 @@ export function registerCli(program: Command, ctx: PluginContext): void {
   for (const role of getAllRoleIds()) {
     for (const level of getLevelsForRole(role)) {
       const flag = `--${role}-${level}`;
-      setupCmd.option(`${flag} <model>`, `${role.toUpperCase()} ${level} model (default: ${defaults[role]?.[level] ?? "auto"})`);
+      setupCmd.option(
+        `${flag} <model>`,
+        `${role.toUpperCase()} ${level} model (default: ${formatModelSpec(defaults[role]?.[level] as ModelSpec | undefined)})`,
+      );
     }
   }
 
@@ -76,7 +80,7 @@ export function registerCli(program: Command, ctx: PluginContext): void {
       console.log("Models configured:");
       for (const [role, levels] of Object.entries(result.models)) {
         for (const [level, model] of Object.entries(levels)) {
-          console.log(`  ${role}.${level}: ${model}`);
+          console.log(`  ${role}.${level}: ${formatModelSpec(model as ModelSpec)}`);
         }
       }
 
@@ -339,4 +343,11 @@ export function registerCli(program: Command, ctx: PluginContext): void {
         process.exit(1);
       }
     });
+}
+
+function formatModelSpec(spec?: ModelSpec): string {
+  if (!spec) return "auto";
+  const normalized = normalizeModelSpec(spec);
+  if (normalized.fallbacks.length === 0) return normalized.primary;
+  return `${normalized.primary} (fallbacks: ${normalized.fallbacks.join(", ")})`;
 }

--- a/lib/setup/cli.ts
+++ b/lib/setup/cli.ts
@@ -7,8 +7,8 @@ import type { Command } from "commander";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../context.js";
 import { runSetup } from "./index.js";
-import { getAllDefaultModels, getAllRoleIds, getLevelsForRole, normalizeModelSpec } from "../roles/index.js";
-import type { ModelSpec } from "../roles/index.js";
+import { getAllDefaultModels, getAllRoleIds, getLevelsForRole, normalizeModelSpec, modelSpecToString } from "../roles/index.js";
+import type { ModelSpec, ModelSpecInput } from "../roles/index.js";
 import { readProjects, writeProjects, type Channel } from "../projects/index.js";
 import { log as auditLog } from "../audit.js";
 
@@ -345,9 +345,7 @@ export function registerCli(program: Command, ctx: PluginContext): void {
     });
 }
 
-function formatModelSpec(spec?: ModelSpec): string {
+function formatModelSpec(spec?: ModelSpecInput): string {
   if (!spec) return "auto";
-  const normalized = normalizeModelSpec(spec);
-  if (normalized.fallbacks.length === 0) return normalized.primary;
-  return `${normalized.primary} (fallbacks: ${normalized.fallbacks.join(", ")})`;
+  return modelSpecToString(normalizeModelSpec(spec));
 }

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -229,13 +229,32 @@ async function writeModelsToWorkflow(workspacePath: string, models: ModelConfig)
 
   // Merge models into roles section
   for (const [role, levels] of Object.entries(models)) {
+    const serializedLevels = serializeModelLevels(levels);
     if (!roles.has(role)) {
-      roles.set(role, doc.createNode({ models: levels }));
+      roles.set(role, doc.createNode({ models: serializedLevels }));
     } else {
       const roleNode = roles.get(role, true) as unknown as YAML.YAMLMap;
-      roleNode.set("models", doc.createNode(levels));
+      roleNode.set("models", doc.createNode(serializedLevels));
     }
   }
 
   await fs.writeFile(workflowPath, doc.toString({ lineWidth: 120 }), "utf-8");
+}
+
+function serializeModelLevels(levels: Record<string, ModelSpec>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [level, spec] of Object.entries(levels)) {
+    const normalized = normalizeModelSpec(spec);
+    if (normalized.fallbacks.length === 0) {
+      result[level] = normalized.primary;
+    } else {
+      result[level] = {
+        model: {
+          primary: normalized.primary,
+          fallbacks: [...normalized.fallbacks],
+        },
+      };
+    }
+  }
+  return result;
 }

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -9,7 +9,8 @@ import path from "node:path";
 import YAML from "yaml";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
-import { getAllDefaultModels } from "../roles/index.js";
+import { getAllDefaultModels, normalizeModelSpec } from "../roles/index.js";
+import type { ModelSpec } from "../roles/index.js";
 import { migrateChannelBinding } from "./binding-manager.js";
 import { createAgent, resolveWorkspacePath } from "./agent.js";
 import { writePluginConfig } from "./config.js";
@@ -17,7 +18,7 @@ import { scaffoldWorkspace } from "./workspace.js";
 import { DATA_DIR } from "./migrate-layout.js";
 import type { ExecutionMode } from "../workflow/index.js";
 
-export type ModelConfig = Record<string, Record<string, string>>;
+export type ModelConfig = Record<string, Record<string, ModelSpec>>;
 
 export type SetupOpts = {
   /** OpenClaw plugin runtime for config access. */
@@ -33,7 +34,7 @@ export type SetupOpts = {
   /** Override workspace path (auto-detected from agent if not given). */
   workspacePath?: string;
   /** Model overrides per role.level. Missing levels use defaults. */
-  models?: Record<string, Partial<Record<string, string>>>;
+  models?: Record<string, Partial<Record<string, string | ModelSpec>>>;
   /** Plugin-level project execution mode: parallel or sequential. Default: parallel. */
   projectExecution?: ExecutionMode;
   /** Injected runCommand for dependency injection. */
@@ -130,19 +131,70 @@ function buildModelConfig(overrides?: SetupOpts["models"]): ModelConfig {
   const result: ModelConfig = {};
 
   for (const [role, levels] of Object.entries(defaults)) {
-    result[role] = { ...levels };
+    result[role] = {};
+    for (const [level, spec] of Object.entries(levels)) {
+      result[role][level] = cloneModelSpec(spec as ModelSpec);
+    }
   }
 
   if (overrides) {
     for (const [role, roleOverrides] of Object.entries(overrides)) {
       if (!result[role]) result[role] = {};
       for (const [level, model] of Object.entries(roleOverrides)) {
-        if (model) result[role][level] = model;
+        if (!model) continue;
+        const parsed = parseModelSpecInput(model as string | ModelSpec);
+        result[role][level] = cloneModelSpec(parsed);
       }
     }
   }
 
   return result;
+}
+
+function parseModelSpecInput(input: string | ModelSpec): ModelSpec {
+  if (typeof input !== "string") {
+    return cloneModelSpec(input);
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Model override cannot be empty");
+  }
+
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === "string") {
+        return parsed;
+      }
+      if (parsed && typeof parsed === "object" && typeof parsed.primary === "string") {
+        const fallbacks = Array.isArray(parsed.fallbacks)
+          ? parsed.fallbacks.filter((f: unknown): f is string => typeof f === "string")
+          : undefined;
+        return fallbacks && fallbacks.length > 0
+          ? { primary: parsed.primary, fallbacks }
+          : parsed.primary;
+      }
+      throw new Error("JSON model spec must include a primary string");
+    } catch (err) {
+      throw new Error(`Invalid model spec JSON: ${(err as Error).message}`);
+    }
+  }
+
+  const csvParts = trimmed.split(",").map((part) => part.trim()).filter((part) => part.length > 0);
+  if (csvParts.length > 1) {
+    const [primary, ...fallbacks] = csvParts;
+    return fallbacks.length > 0 ? { primary, fallbacks } : primary;
+  }
+
+  return trimmed;
+}
+
+function cloneModelSpec(spec: ModelSpec): ModelSpec {
+  const normalized = normalizeModelSpec(spec);
+  return normalized.fallbacks.length > 0
+    ? { primary: normalized.primary, fallbacks: [...normalized.fallbacks] }
+    : normalized.primary;
 }
 
 function getDefaultWorkspacePath(runtime: PluginRuntime): string | undefined {

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -10,7 +10,7 @@ import YAML from "yaml";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import { getAllDefaultModels, normalizeModelSpec } from "../roles/index.js";
-import type { ModelSpec } from "../roles/index.js";
+import type { ModelSpec, ModelSpecInput } from "../roles/index.js";
 import { migrateChannelBinding } from "./binding-manager.js";
 import { createAgent, resolveWorkspacePath } from "./agent.js";
 import { writePluginConfig } from "./config.js";
@@ -34,7 +34,7 @@ export type SetupOpts = {
   /** Override workspace path (auto-detected from agent if not given). */
   workspacePath?: string;
   /** Model overrides per role.level. Missing levels use defaults. */
-  models?: Record<string, Partial<Record<string, string | ModelSpec>>>;
+  models?: Record<string, Partial<Record<string, ModelSpecInput>>>;
   /** Plugin-level project execution mode: parallel or sequential. Default: parallel. */
   projectExecution?: ExecutionMode;
   /** Injected runCommand for dependency injection. */
@@ -151,7 +151,7 @@ function buildModelConfig(overrides?: SetupOpts["models"]): ModelConfig {
   return result;
 }
 
-function parseModelSpecInput(input: string | ModelSpec): ModelSpec {
+function parseModelSpecInput(input: string | ModelSpecInput): ModelSpec {
   if (typeof input !== "string") {
     return cloneModelSpec(input);
   }
@@ -165,15 +165,13 @@ function parseModelSpecInput(input: string | ModelSpec): ModelSpec {
     try {
       const parsed = JSON.parse(trimmed);
       if (typeof parsed === "string") {
-        return parsed;
+        return cloneModelSpec(parsed);
       }
       if (parsed && typeof parsed === "object" && typeof parsed.primary === "string") {
         const fallbacks = Array.isArray(parsed.fallbacks)
           ? parsed.fallbacks.filter((f: unknown): f is string => typeof f === "string")
-          : undefined;
-        return fallbacks && fallbacks.length > 0
-          ? { primary: parsed.primary, fallbacks }
-          : parsed.primary;
+          : [];
+        return cloneModelSpec({ primary: parsed.primary, fallbacks });
       }
       throw new Error("JSON model spec must include a primary string");
     } catch (err) {
@@ -184,17 +182,15 @@ function parseModelSpecInput(input: string | ModelSpec): ModelSpec {
   const csvParts = trimmed.split(",").map((part) => part.trim()).filter((part) => part.length > 0);
   if (csvParts.length > 1) {
     const [primary, ...fallbacks] = csvParts;
-    return fallbacks.length > 0 ? { primary, fallbacks } : primary;
+    return cloneModelSpec({ primary, fallbacks });
   }
 
-  return trimmed;
+  return cloneModelSpec(trimmed);
 }
 
-function cloneModelSpec(spec: ModelSpec): ModelSpec {
+function cloneModelSpec(spec: ModelSpecInput): ModelSpec {
   const normalized = normalizeModelSpec(spec);
-  return normalized.fallbacks.length > 0
-    ? { primary: normalized.primary, fallbacks: [...normalized.fallbacks] }
-    : normalized.primary;
+  return { primary: normalized.primary, fallbacks: [...normalized.fallbacks] };
 }
 
 function getDefaultWorkspacePath(runtime: PluginRuntime): string | undefined {

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -39,7 +39,7 @@ export type CapturedCommand = {
   /** Extracted from gateway `agent` call params, if applicable. */
   agentModel?: string;
   /** Extracted from gateway `sessions.patch` params, if applicable. */
-  sessionPatch?: { key: string; model: string; label?: string };
+  sessionPatch?: { key: string; model: string; label?: string; fallbacks?: string[] };
 };
 
 export type CommandInterceptor = {
@@ -54,7 +54,7 @@ export type CommandInterceptor = {
   /** Get all agent models sent via `openclaw gateway call agent`. */
   agentModels(): string[];
   /** Get all session patches. */
-  sessionPatches(): Array<{ key: string; model: string; label?: string }>;
+  sessionPatches(): Array<{ key: string; model: string; label?: string; fallbacks?: string[] }>;
   /** Reset captured commands. */
   reset(): void;
 };
@@ -92,7 +92,12 @@ function createCommandInterceptor(): {
             }
           }
           if (rpcMethod === "sessions.patch") {
-            captured.sessionPatch = { key: params.key, model: params.model, label: params.label };
+            captured.sessionPatch = {
+              key: params.key,
+              model: params.model,
+              label: params.label,
+              fallbacks: Array.isArray(params.fallbacks) ? params.fallbacks : undefined,
+            };
           }
         } catch { /* ignore parse errors */ }
       }

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -9,17 +9,21 @@ import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { runSetup, type SetupOpts } from "../../setup/index.js";
 import { writeAllDefaults } from "../../setup/workspace.js";
-import { getAllDefaultModels, getAllRoleIds, getLevelsForRole } from "../../roles/index.js";
+import { getAllDefaultModels, getAllRoleIds, getLevelsForRole, normalizeModelSpec } from "../../roles/index.js";
+import type { ModelSpec } from "../../roles/index.js";
 import { ExecutionMode } from "../../workflow/index.js";
 
 export function createSetupTool(ctx: PluginContext) {
-  return (toolCtx: ToolContext) => ({
-    name: "setup",
-    label: "Setup",
-    description: `Execute DevClaw setup. Creates AGENTS.md, HEARTBEAT.md, TOOLS.md, devclaw/projects.json, devclaw/prompts/, and model level config. Optionally creates a new agent with channel binding. Called after onboard collects configuration.`,
-    parameters: {
-      type: "object",
-      properties: {
+  return (toolCtx: ToolContext) => {
+    const defaults = getAllDefaultModels();
+
+    return {
+      name: "setup",
+      label: "Setup",
+      description: `Execute DevClaw setup. Creates AGENTS.md, HEARTBEAT.md, TOOLS.md, devclaw/projects.json, devclaw/prompts/, and model level config. Optionally creates a new agent with channel binding. Called after onboard collects configuration.`,
+      parameters: {
+        type: "object",
+        properties: {
         newAgentName: {
           type: "string",
           description:
@@ -45,7 +49,7 @@ export function createSetupTool(ctx: PluginContext) {
               properties: Object.fromEntries(
                 getLevelsForRole(role).map((level) => [level, {
                   type: "string",
-                  description: `Default: ${getAllDefaultModels()[role]?.[level] ?? "auto"}`,
+                  description: `Default: ${formatModelSpec(defaults[role]?.[level] as ModelSpec | undefined)}`,
                 }]),
               ),
             }]),
@@ -115,7 +119,7 @@ export function createSetupTool(ctx: PluginContext) {
       lines.push("Models:");
       for (const [role, levels] of Object.entries(result.models)) {
         for (const [level, model] of Object.entries(levels)) {
-          lines.push(`  ${role}.${level}: ${model}`);
+          lines.push(`  ${role}.${level}: ${formatModelSpec(model as ModelSpec)}`);
         }
       }
       lines.push("");
@@ -135,5 +139,13 @@ export function createSetupTool(ctx: PluginContext) {
         summary: lines.join("\n"),
       });
     },
-  });
+    };
+  };
+}
+
+function formatModelSpec(spec?: ModelSpec): string {
+  if (!spec) return "auto";
+  const normalized = normalizeModelSpec(spec);
+  if (normalized.fallbacks.length === 0) return normalized.primary;
+  return `${normalized.primary} (fallbacks: ${normalized.fallbacks.join(", ")})`;
 }

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -9,8 +9,8 @@ import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { runSetup, type SetupOpts } from "../../setup/index.js";
 import { writeAllDefaults } from "../../setup/workspace.js";
-import { getAllDefaultModels, getAllRoleIds, getLevelsForRole, normalizeModelSpec } from "../../roles/index.js";
-import type { ModelSpec } from "../../roles/index.js";
+import { getAllDefaultModels, getAllRoleIds, getLevelsForRole, normalizeModelSpec, modelSpecToString } from "../../roles/index.js";
+import type { ModelSpec, ModelSpecInput } from "../../roles/index.js";
 import { ExecutionMode } from "../../workflow/index.js";
 
 export function createSetupTool(ctx: PluginContext) {
@@ -143,9 +143,7 @@ export function createSetupTool(ctx: PluginContext) {
   };
 }
 
-function formatModelSpec(spec?: ModelSpec): string {
+function formatModelSpec(spec?: ModelSpecInput): string {
   if (!spec) return "auto";
-  const normalized = normalizeModelSpec(spec);
-  if (normalized.fallbacks.length === 0) return normalized.primary;
-  return `${normalized.primary} (fallbacks: ${normalized.fallbacks.join(", ")})`;
+  return modelSpecToString(normalizeModelSpec(spec));
 }

--- a/lib/tools/tasks/research-task.test.ts
+++ b/lib/tools/tasks/research-task.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { parseDevClawSessionKey } from "../../dispatch/bootstrap-hook.js";
-import { isLevelForRole, roleForLevel, resolveModel, getDefaultModel, getEmoji } from "../../roles/index.js";
+import { isLevelForRole, roleForLevel, resolveModel, getDefaultModel, getEmoji, normalizeModelSpec } from "../../roles/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
 import {
   DEFAULT_WORKFLOW, getQueueLabels, getCompletionRule,
@@ -28,13 +28,21 @@ describe("architect tiers", () => {
   });
 
   it("should resolve default architect models", () => {
-    assert.strictEqual(getDefaultModel("architect", "senior"), "anthropic/claude-opus-4-6");
-    assert.strictEqual(getDefaultModel("architect", "junior"), "anthropic/claude-sonnet-4-5");
+    assert.strictEqual(getDefaultModel("architect", "senior")?.primary, "anthropic/claude-opus-4-6");
+    assert.strictEqual(getDefaultModel("architect", "junior")?.primary, "anthropic/claude-sonnet-4-5");
   });
 
   it("should resolve architect model from resolved role config", () => {
-    const resolvedRole = { levelMaxWorkers: { junior: 2, senior: 2 }, models: { senior: "custom/model" }, levels: ["junior", "senior"], defaultLevel: "junior", emoji: {}, completionResults: [] as string[], enabled: true };
-    assert.strictEqual(resolveModel("architect", "senior", resolvedRole), "custom/model");
+    const resolvedRole = {
+      levelMaxWorkers: { junior: 2, senior: 2 },
+      models: { senior: normalizeModelSpec("custom/model") },
+      levels: ["junior", "senior"],
+      defaultLevel: "junior",
+      emoji: {},
+      completionResults: [] as string[],
+      enabled: true,
+    };
+    assert.strictEqual(resolveModel("architect", "senior", resolvedRole).primary, "custom/model");
   });
 
   it("should have architect emoji", () => {

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -196,8 +196,8 @@ Example:
         research: {
           sessionKey: dr.sessionKey,
           level: dr.level,
-          model: dr.model,
-          fallbacks: dr.fallbacks,
+          model: dr.model.primary,
+          fallbacks: dr.model.fallbacks.length > 0 ? dr.model.fallbacks : undefined,
           sessionAction: dr.sessionAction,
           status: "in_progress",
         },

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -23,7 +23,7 @@ import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider,
 import { loadConfig } from "../../config/index.js";
 import { getActiveLabel } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
-import { resolveModel, normalizeModelSpec } from "../../roles/index.js";
+import { resolveModel } from "../../roles/index.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -120,7 +120,6 @@ Example:
       const resolvedConfig = await loadConfig(workspaceDir, project.name);
       const resolvedRole = resolvedConfig.roles[role];
       const modelSpec = resolveModel(role, level, resolvedRole);
-      const normalizedModel = normalizeModelSpec(modelSpec);
 
       if (dryRun) {
         return jsonResult({
@@ -129,8 +128,8 @@ Example:
           issue: { title, label: TO_RESEARCH_LABEL },
           research: {
             level,
-            model: normalizedModel.primary,
-            fallbacks: normalizedModel.fallbacks.length > 0 ? normalizedModel.fallbacks : undefined,
+            model: modelSpec.primary,
+            fallbacks: modelSpec.fallbacks.length > 0 ? modelSpec.fallbacks : undefined,
             status: "dry_run",
           },
           announcement: `\u{1f4d0} [DRY RUN] Would create research ticket and dispatch ${role} (${level}) for: ${title}`,

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -23,7 +23,7 @@ import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider,
 import { loadConfig } from "../../config/index.js";
 import { getActiveLabel } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
-import { resolveModel } from "../../roles/index.js";
+import { resolveModel, normalizeModelSpec } from "../../roles/index.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -119,14 +119,20 @@ Example:
         : selectLevel(title, description, role).level;
       const resolvedConfig = await loadConfig(workspaceDir, project.name);
       const resolvedRole = resolvedConfig.roles[role];
-      const model = resolveModel(role, level, resolvedRole);
+      const modelSpec = resolveModel(role, level, resolvedRole);
+      const normalizedModel = normalizeModelSpec(modelSpec);
 
       if (dryRun) {
         return jsonResult({
           success: true,
           dryRun: true,
           issue: { title, label: TO_RESEARCH_LABEL },
-          research: { level, model, status: "dry_run" },
+          research: {
+            level,
+            model: normalizedModel.primary,
+            fallbacks: normalizedModel.fallbacks.length > 0 ? normalizedModel.fallbacks : undefined,
+            status: "dry_run",
+          },
           announcement: `\u{1f4d0} [DRY RUN] Would create research ticket and dispatch ${role} (${level}) for: ${title}`,
         });
       }
@@ -192,6 +198,7 @@ Example:
           sessionKey: dr.sessionKey,
           level: dr.level,
           model: dr.model,
+          fallbacks: dr.fallbacks,
           sessionAction: dr.sessionAction,
           status: "in_progress",
         },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,26 @@
   "description": "Multi-project dev/qa pipeline orchestration for OpenClaw. Developer tiers, atomic task management, session health, and audit logging.",
   "configSchema": {
     "type": "object",
+    "$defs": {
+      "ModelSpec": {
+        "type": "object",
+        "properties": {
+          "primary": { "type": "string" },
+          "fallbacks": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["primary"],
+        "additionalProperties": false
+      },
+      "ModelSpecOrString": {
+        "anyOf": [
+          { "type": "string" },
+          { "$ref": "#/$defs/ModelSpec" }
+        ]
+      }
+    },
     "properties": {
       "models": {
         "type": "object",
@@ -13,17 +33,17 @@
             "type": "object",
             "description": "Developer tier models",
             "properties": {
-              "junior": { "type": "string" },
-              "medior": { "type": "string" },
-              "senior": { "type": "string" }
+              "junior": { "$ref": "#/$defs/ModelSpecOrString" },
+              "medior": { "$ref": "#/$defs/ModelSpecOrString" },
+              "senior": { "$ref": "#/$defs/ModelSpecOrString" }
             }
           },
           "qa": {
             "type": "object",
             "description": "QA tier models",
             "properties": {
-              "reviewer": { "type": "string" },
-              "tester": { "type": "string" }
+              "reviewer": { "$ref": "#/$defs/ModelSpecOrString" },
+              "tester": { "$ref": "#/$defs/ModelSpecOrString" }
             }
           }
         }


### PR DESCRIPTION
Closes #1 

## Summary
- allow roles to specify primary model + fallback chain via ModelSpec
- plumb fallbacks through dispatch, session patches, notify, setup CLI/tools
- document new syntax and update tests/harness to cover fallback round-tripping
